### PR TITLE
Resolve issue #23

### DIFF
--- a/DotNetVault.Test/DotNetVault.Test.csproj
+++ b/DotNetVault.Test/DotNetVault.Test.csproj
@@ -97,7 +97,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="HighPrecisionTimeStamps" Version="1.0.0.1" />
+    <PackageReference Include="HighPrecisionTimeStamps" Version="1.0.0.6" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/DotNetVault.Vsix/DotNetVault.Vsix.csproj
+++ b/DotNetVault.Vsix/DotNetVault.Vsix.csproj
@@ -74,8 +74,8 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="HighPrecisionTimeStamps, Version=1.0.0.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\HighPrecisionTimeStamps.1.0.0.1\lib\netstandard2.0\HighPrecisionTimeStamps.dll</HintPath>
+    <Reference Include="HighPrecisionTimeStamps, Version=1.0.0.6, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\HighPrecisionTimeStamps.1.0.0.6\lib\netstandard2.0\HighPrecisionTimeStamps.dll</HintPath>
     </Reference>
     <Reference Include="JetBrains.Annotations, Version=2021.2.0.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
       <HintPath>..\packages\JetBrains.Annotations.2021.2.0\lib\net20\JetBrains.Annotations.dll</HintPath>
@@ -83,6 +83,9 @@
     <Reference Include="System" />
     <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Collections.Immutable, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.5.0.0\lib\net461\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>

--- a/DotNetVault.Vsix/packages.config
+++ b/DotNetVault.Vsix/packages.config
@@ -1,8 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="HighPrecisionTimeStamps" version="1.0.0.1" targetFramework="net48" />
+  <package id="HighPrecisionTimeStamps" version="1.0.0.6" targetFramework="net48" />
   <package id="JetBrains.Annotations" version="2021.2.0" targetFramework="net48" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net48" />
+  <package id="System.Collections.Immutable" version="5.0.0" targetFramework="net48" />
   <package id="System.Memory" version="4.5.4" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net48" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="5.0.0" targetFramework="net48" />

--- a/DotNetVault/DotNetVault.csproj
+++ b/DotNetVault/DotNetVault.csproj
@@ -134,7 +134,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="HighPrecisionTimeStamps" Version="1.0.0.1">
+    <PackageReference Include="HighPrecisionTimeStamps" Version="1.0.0.6">
       <GeneratePathProperty>true</GeneratePathProperty>
       <IncludeAssets>all</IncludeAssets>
       <IncludeInPackage>true</IncludeInPackage>
@@ -159,7 +159,7 @@
 
   <ItemGroup>
     <None Update="tools\*.ps1" CopyToOutputDirectory="Always" Pack="true" PackagePath="" />
-    <None Include="$(PkgHighPrecisionTimeStamps)\lib\netstandard2.0\*.dll"  Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false"/>
+    <None Include="$(PkgHighPrecisionTimeStamps)\lib\netstandard2.0\*.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     <None Include="$(OutputPath)\license.txt" Pack="true" PackagePath="Docs" Visible="false" />
     <None Include="$(OutputPath)\Quick_Start_Functionality_Tour.md" Pack="true" PackagePath="Docs" Visible="false" />
     <None Include="$(OutputPath)\Quick_Start_Install_Rider_Amazon_Linux.md" Pack="true" PackagePath="Docs" Visible="false" />


### PR DESCRIPTION
Upgrade HighPrecisionTimeStamps used by analyzer to version 1.0.0.6 to resolve analyzer-thrown exceptions described in issue #23.