### PR TITLE
Imported updates from v1.0_master

### DIFF
--- a/DotNetVault.Test/DotNetVault.Test.csproj
+++ b/DotNetVault.Test/DotNetVault.Test.csproj
@@ -97,7 +97,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="HighPrecisionTimeStamps" Version="1.0.0.1" />
+    <PackageReference Include="HighPrecisionTimeStamps" Version="1.0.0.6" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/DotNetVault.Vsix/DotNetVault.Vsix.csproj
+++ b/DotNetVault.Vsix/DotNetVault.Vsix.csproj
@@ -74,8 +74,8 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="HighPrecisionTimeStamps, Version=1.0.0.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\HighPrecisionTimeStamps.1.0.0.1\lib\netstandard2.0\HighPrecisionTimeStamps.dll</HintPath>
+    <Reference Include="HighPrecisionTimeStamps, Version=1.0.0.6, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\HighPrecisionTimeStamps.1.0.0.6\lib\netstandard2.0\HighPrecisionTimeStamps.dll</HintPath>
     </Reference>
     <Reference Include="JetBrains.Annotations, Version=2021.2.0.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
       <HintPath>..\packages\JetBrains.Annotations.2021.2.0\lib\net20\JetBrains.Annotations.dll</HintPath>
@@ -83,6 +83,9 @@
     <Reference Include="System" />
     <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Collections.Immutable, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.5.0.0\lib\net461\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>

--- a/DotNetVault.Vsix/packages.config
+++ b/DotNetVault.Vsix/packages.config
@@ -1,8 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="HighPrecisionTimeStamps" version="1.0.0.1" targetFramework="net48" />
+  <package id="HighPrecisionTimeStamps" version="1.0.0.6" targetFramework="net48" />
   <package id="JetBrains.Annotations" version="2021.2.0" targetFramework="net48" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net48" />
+  <package id="System.Collections.Immutable" version="5.0.0" targetFramework="net48" />
   <package id="System.Memory" version="4.5.4" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net48" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="5.0.0" targetFramework="net48" />

--- a/DotNetVault/DotNetVault.csproj
+++ b/DotNetVault/DotNetVault.csproj
@@ -134,7 +134,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="HighPrecisionTimeStamps" Version="1.0.0.1">
+    <PackageReference Include="HighPrecisionTimeStamps" Version="1.0.0.6">
       <GeneratePathProperty>true</GeneratePathProperty>
       <IncludeAssets>all</IncludeAssets>
       <IncludeInPackage>true</IncludeInPackage>
@@ -159,7 +159,7 @@
 
   <ItemGroup>
     <None Update="tools\*.ps1" CopyToOutputDirectory="Always" Pack="true" PackagePath="" />
-    <None Include="$(PkgHighPrecisionTimeStamps)\lib\netstandard2.0\*.dll"  Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false"/>
+    <None Include="$(PkgHighPrecisionTimeStamps)\lib\netstandard2.0\*.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     <None Include="$(OutputPath)\license.txt" Pack="true" PackagePath="Docs" Visible="false" />
     <None Include="$(OutputPath)\Quick_Start_Functionality_Tour.md" Pack="true" PackagePath="Docs" Visible="false" />
     <None Include="$(OutputPath)\Quick_Start_Install_Rider_Amazon_Linux.md" Pack="true" PackagePath="Docs" Visible="false" />

--- a/DotNetVault/Vaults/BasicMonitorVault.cs
+++ b/DotNetVault/Vaults/BasicMonitorVault.cs
@@ -24,31 +24,27 @@ namespace DotNetVault.Vaults
         /// <summary>
         /// Fallback timeout used when supplied timeout not valid.
         /// </summary>
-        public static TimeSpan FallbackTimeout => TimeSpan.FromMilliseconds(250); 
+        public static TimeSpan FallbackTimeout => TimeSpan.FromMilliseconds(250);
         #endregion
 
         #region CTORS
         /// <inheritdoc />
         public BasicMonitorVault(TimeSpan defaultTimeout)
-            : base(defaultTimeout) { }
+            : this(defaultTimeout, default) { }
 
         /// <summary>
         /// Creates a vault.  The value of <see cref="FallbackTimeout"/> will be used as default timeout.
         ///  </summary>
         /// <param name="initialValue">initial value of protected resource</param>
-        public BasicMonitorVault(T initialValue) : this(initialValue, FallbackTimeout)
-        {
-
-        }
+        public BasicMonitorVault(T initialValue)
+            : this(initialValue, FallbackTimeout) { }
 
         /// <summary>
         /// Creates a vault using the default value of the protected resource and the value
         /// specified by <see cref="FallbackTimeout"/> as the default wait period.
         /// </summary>
-        public BasicMonitorVault() : this(default, FallbackTimeout)
-        {
-
-        }
+        public BasicMonitorVault()
+            : this(default, FallbackTimeout) { }
 
         /// <summary>
         /// CTOR -- vault with specified value and timeout
@@ -56,11 +52,15 @@ namespace DotNetVault.Vaults
         /// <param name="initialValue">initial value of protected resource</param>
         /// <param name="defaultTimeout">default timeout period</param>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="defaultTimeout"/> was null</exception>
-        public BasicMonitorVault(T initialValue, TimeSpan defaultTimeout) : base(defaultTimeout)
+        public BasicMonitorVault(T initialValue, TimeSpan defaultTimeout)
+            : this(defaultTimeout, initialValue) { }
+
+        private BasicMonitorVault(TimeSpan defaultTimeout, T initialValue)
+            : base(defaultTimeout)
         {
             Init(initialValue);
             Debug.Assert(BoxPtr != null);
-        } 
+        }
         #endregion
 
         #region Lock acquisition methods

--- a/VaultUnitTests/BasicMonVAcqBehaviorTests.cs
+++ b/VaultUnitTests/BasicMonVAcqBehaviorTests.cs
@@ -6,10 +6,13 @@ using Xunit;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 using ResourceType = System.String;
-
+using NullVtType = System.Nullable<System.UInt64>;
+using VtType = System.UInt64;
 namespace VaultUnitTests
 {
     using VaultType = DotNetVault.Vaults.BasicMonitorVault<ResourceType>;
+    using NullVtVault = DotNetVault.Vaults.BasicMonitorVault<NullVtType>;
+    using VtVault = DotNetVault.Vaults.BasicMonitorVault<VtType>;
 
     public delegate VaultType MonVaultCreationMethod(TimeSpan timeout, Func<ResourceType> ctor = null);
     public sealed class BasicMonVaultAcqBehaviorTests : VaultAcqBehaviorTest
@@ -20,7 +23,8 @@ namespace VaultUnitTests
             _meth = (ts, ctor) => Fixture.CreateBasicMonitorVault<ResourceType>();
         }
 
-        
+
+
         [Fact]
         public void TestThrowsAlready()
         {
@@ -229,7 +233,7 @@ namespace VaultUnitTests
         public void TestSeqBlockAcqs()
         {
             string finalResult;
-            using (var vault = _meth(TimeSpan.FromMilliseconds(250)))
+            using (VaultType vault = _meth(TimeSpan.FromMilliseconds(250)))
             {
                 vault.SetCurrentValue(TimeSpan.FromMilliseconds(10), string.Empty);
 

--- a/VaultUnitTests/Issue22Tests.cs
+++ b/VaultUnitTests/Issue22Tests.cs
@@ -1,0 +1,142 @@
+﻿using System;
+using JetBrains.Annotations;
+using Xunit;
+using Xunit.Abstractions;
+using ResourceType = System.String;
+using NullVtType = System.Nullable<System.UInt64>;
+using VtType = System.UInt64;
+namespace VaultUnitTests
+{
+    using VaultType = DotNetVault.Vaults.BasicMonitorVault<ResourceType>;
+    using NullVtVault = DotNetVault.Vaults.BasicMonitorVault<NullVtType>;
+    using VtVault = DotNetVault.Vaults.BasicMonitorVault<VtType>;
+    public class Issue22Tests  : NullableAcqTests
+    {
+        /// <inheritdoc />
+        public Issue22Tests([NotNull] ITestOutputHelper helper,
+            [NotNull] NullableVtVaultFactoryFixture fixture) : base(helper, fixture) {}
+
+        [Fact]
+        public void TestGetLockUnsetNullableVt()
+        {
+            using (var vault = Fixture.CreateUnsetNullableVtVault())
+            {
+                {
+                    using var lck = vault.Lock();
+                    Helper.WriteLine($"Value now: {lck.Value?.ToString() ?? "NULL"}.");
+                }
+            }
+        }
+
+        [Fact]
+        public void TestGetLockPresetNullableVt()
+        {
+            const ulong targetVal = 24;
+            using (var vault = Fixture.CreateUnsetNullableVtVault())
+            {
+                vault.SetCurrentValue(TimeSpan.FromMilliseconds(250), targetVal);
+                {
+                    using var lck = vault.Lock();
+                    Assert.True(lck.Value == targetVal);
+                }
+            }
+        }
+
+        [Fact]
+        public void TestGetLockConstructedNullableVt()
+        {
+            const ulong targetVal = 66;
+            using (var vault = Fixture.CreateSetNullVtVault(targetVal))
+            {
+                using var lck = vault.Lock();
+                Assert.True(lck.Value == targetVal);
+            }
+        }
+
+        [Fact]
+        public void TestGetLockUnsetVt()
+        {
+            using (var vault = Fixture.CreateUnsetVtVault())
+            {
+                {
+                    using var lck = vault.Lock();
+                    Helper.WriteLine($"Value now: {lck.Value.ToString()}.");
+                }
+            }
+        }
+
+        [Fact]
+        public void TestGetLockPresetVt()
+        {
+            const ulong targetVal = 24;
+            using (var vault = Fixture.CreateUnsetVtVault())
+            {
+                vault.SetCurrentValue(TimeSpan.FromMilliseconds(250), targetVal);
+                {
+                    using var lck = vault.Lock();
+                    Assert.True(lck.Value == targetVal);
+                }
+            }
+        }
+
+        [Fact]
+        public void TestGetLockConstructedVt()
+        {
+            const ulong targetVal = 66;
+            using (var vault = Fixture.CreateSetVtVault(targetVal))
+            {
+                using var lck = vault.Lock();
+                Assert.True(lck.Value == targetVal);
+            }
+        }
+
+        [Fact]
+        public void TestGetLockUnsetRt()
+        {
+            using (var vault = Fixture.CreateUnsetVault())
+            {
+                {
+                    using var lck = vault.Lock();
+                    Helper.WriteLine($"Value now: {lck.Value ?? "NULL"}.");
+                }
+            }
+        }
+
+        [Fact]
+        public void TestGetLockPreset()
+        {
+            const string targetVal = "FooBar";
+            using (var vault = Fixture.CreateUnsetVault())
+            {
+                vault.SetCurrentValue(TimeSpan.FromMilliseconds(250), targetVal);
+                {
+                    using var lck = vault.Lock();
+                    Assert.True(lck.Value == targetVal);
+                }
+            }
+        }
+
+        [Fact]
+        public void TestGetLockConstructedNullRt()
+        {
+            const string targetVal = null;
+            using (var vault = Fixture.CreateSetVault(targetVal))
+            {
+                using var lck = vault.Lock();
+                Assert.True(lck.Value == targetVal);
+            }
+        }
+
+        [Fact]
+        public void TestGetLockConstructedNotNullRtVault()
+        {
+            const string targetVal = "frobnication";
+            using (var vault = Fixture.CreateSetVault(targetVal))
+            {
+                using var lck = vault.Lock();
+                Assert.True(lck.Value == targetVal);
+            }
+        }
+
+    }
+}

--- a/VaultUnitTests/VaultAcqBehaviorTest.cs
+++ b/VaultUnitTests/VaultAcqBehaviorTest.cs
@@ -1,12 +1,20 @@
 ﻿using System;
+using DotNetVault.Exceptions;
 using JetBrains.Annotations;
 using Xunit;
 using Xunit.Abstractions;
-
+using ResourceType = System.String;
+using NullVtType = System.Nullable<ulong>;
+using VtType = System.UInt64;
 namespace VaultUnitTests
 {
+    using VaultType = DotNetVault.Vaults.BasicMonitorVault<ResourceType>;
+    using NullVtVault = DotNetVault.Vaults.BasicMonitorVault<NullVtType>;
+    using VtVault = DotNetVault.Vaults.BasicMonitorVault<VtType>;
     public abstract class VaultAcqBehaviorTest : TestBase<VaultFactoryFixture>
     {
+
+
         protected VaultAcqBehaviorTest([NotNull] ITestOutputHelper helper, [NotNull] VaultFactoryFixture fixture) : base(helper, fixture)
         {
         }
@@ -23,4 +31,39 @@ namespace VaultUnitTests
             Fixture = fixture ?? throw new ArgumentNullException(nameof(fixture));
         }
     }
+
+    public class NullableVtVaultFactoryFixture : VaultFactoryFixture
+    {
+        public TimeSpan VaultTimeout
+        {
+            get => _timeout;
+            init => _timeout = value > TimeSpan.Zero
+                ? value
+                : throw new ArgumentNotPositiveException<TimeSpan>(nameof(value), value);
+        }
+
+        public NullVtVault CreateSetNullVtVault(NullVtType initial) => new(initial, _timeout);
+
+        public NullVtVault CreateUnsetNullableVtVault() => new(_timeout);
+
+        public VtVault CreateUnsetVtVault() => new(_timeout);
+
+        public VtVault CreateSetVtVault(VtType value) => new(value, _timeout);
+
+        public VaultType CreateUnsetVault() => new(_timeout);
+
+        public VaultType CreateSetVault(ResourceType rt) => new(rt, _timeout);
+
+
+        private readonly TimeSpan _timeout = TimeSpan.FromMilliseconds(500);
+    }
+
+    public abstract class NullableAcqTests : TestBase<NullableVtVaultFactoryFixture>
+    {
+        /// <inheritdoc />
+        protected NullableAcqTests([NotNull] ITestOutputHelper helper,
+            [NotNull] NullableVtVaultFactoryFixture fixture) : base(helper, fixture) { }
+    }
+
+
 }

--- a/VaultUnitTests/VaultUnitTests.csproj
+++ b/VaultUnitTests/VaultUnitTests.csproj
@@ -5,6 +5,7 @@
     <SccProvider>SAK</SccProvider>
     <SccAuxPath>SAK</SccAuxPath>
     <SccLocalPath>SAK</SccLocalPath>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -26,7 +27,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="HighPrecisionTimeStamps" Version="1.0.0.1" />
+    <PackageReference Include="HighPrecisionTimeStamps" Version="1.0.0.6" />
+    <PackageReference Include="IsExternalInit" Version="1.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="JetBrains.Annotations" Version="2021.2.0" />
     <PackageReference Include="JetBrains.DotMemoryUnit" Version="3.1.20200127.214830" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />


### PR DESCRIPTION
Imported updates from v1.0_master:  
- upgrade (HpTimeStamps minv- 1.0.0.6)

- fix problem with basic monitor vault when initial value not supplied to ctor.