### PR TITLE
Updated nuget packages (SDK 17)

### DIFF
--- a/DotNetVault.Test/DotNetVault.Test.csproj
+++ b/DotNetVault.Test/DotNetVault.Test.csproj
@@ -98,14 +98,14 @@
 
   <ItemGroup>
     <PackageReference Include="HighPrecisionTimeStamps" Version="1.0.0.6" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2">
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.8.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
     <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
   </ItemGroup>
 

--- a/DotNetVault.Vsix/DotNetVault.Vsix.csproj
+++ b/DotNetVault.Vsix/DotNetVault.Vsix.csproj
@@ -77,8 +77,8 @@
     <Reference Include="HighPrecisionTimeStamps, Version=1.0.0.6, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\HighPrecisionTimeStamps.1.0.0.6\lib\netstandard2.0\HighPrecisionTimeStamps.dll</HintPath>
     </Reference>
-    <Reference Include="JetBrains.Annotations, Version=2021.2.0.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.Annotations.2021.2.0\lib\net20\JetBrains.Annotations.dll</HintPath>
+    <Reference Include="JetBrains.Annotations, Version=2021.3.0.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.Annotations.2021.3.0\lib\net20\JetBrains.Annotations.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">

--- a/DotNetVault.Vsix/packages.config
+++ b/DotNetVault.Vsix/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="HighPrecisionTimeStamps" version="1.0.0.6" targetFramework="net48" />
-  <package id="JetBrains.Annotations" version="2021.2.0" targetFramework="net48" />
+  <package id="JetBrains.Annotations" version="2021.3.0" targetFramework="net48" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net48" />
   <package id="System.Collections.Immutable" version="5.0.0" targetFramework="net48" />
   <package id="System.Memory" version="4.5.4" targetFramework="net48" />

--- a/DotNetVault/DotNetVault.csproj
+++ b/DotNetVault/DotNetVault.csproj
@@ -140,9 +140,9 @@
       <IncludeInPackage>true</IncludeInPackage>
     </PackageReference>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="JetBrains.Annotations" Version="2021.2.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.8.0" PrivateAssets="all" />
+    <PackageReference Include="JetBrains.Annotations" Version="2021.3.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.11.0" PrivateAssets="all" />
     <PackageReference Update="NETStandard.Library" PrivateAssets="all" />
   </ItemGroup>
 

--- a/DotNetVault/DotNetVaultAnalyzer.cs
+++ b/DotNetVault/DotNetVaultAnalyzer.cs
@@ -265,7 +265,7 @@ namespace DotNetVault
                 // ReSharper disable once ConditionIsAlwaysTrueOrFalse -- DEBUG vs RELEASE
                 if (noInvAttrib != null)
                 {
-                    if (context.Node.Kind() == SyntaxKind.InvocationExpression &&
+                    if (context.Node.IsKind(SyntaxKind.InvocationExpression) &&
                         context.Node is InvocationExpressionSyntax ies)
                     {
                         var model = context.SemanticModel;
@@ -430,7 +430,7 @@ namespace DotNetVault
             try
             {
                 var compilation = context.Compilation;
-                if (context.Node.Kind() == SyntaxKind.ObjectCreationExpression)
+                if (context.Node.IsKind(SyntaxKind.ObjectCreationExpression))
                 {
                     INamedTypeSymbol nts;
 
@@ -662,7 +662,7 @@ namespace DotNetVault
                                                 select (arg, symbolIn.Symbol));
 
                                         var illegalBcNotByConstRef = invocationsWhereProtectedInArgumentList
-                                            .Where(inv => inv.arg.RefKindKeyword.Kind() != SyntaxKind.InKeyword)
+                                            .Where(inv => !inv.arg.RefKindKeyword.IsKind(SyntaxKind.InKeyword))
                                             .ToImmutableArray();
 
 

--- a/DotNetVault/UtilitySources/UsingStatementAnalyzerUtilitySource.cs
+++ b/DotNetVault/UtilitySources/UsingStatementAnalyzerUtilitySource.cs
@@ -185,7 +185,7 @@ namespace DotNetVault.UtilitySources
                             isTerminal = true;
                             break;
                         case SyntaxKind.LocalDeclarationStatement:
-                            isOk = parent.DescendantTokens().Any(token => token.Kind() == SyntaxKind.UsingKeyword);
+                            isOk = parent.DescendantTokens().Any(token => token.IsKind(SyntaxKind.UsingKeyword));
                             isTerminal = true;
                             break;
                         default:

--- a/VaultUnitTests/VaultUnitTests.csproj
+++ b/VaultUnitTests/VaultUnitTests.csproj
@@ -32,9 +32,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="JetBrains.Annotations" Version="2021.2.0" />
+    <PackageReference Include="JetBrains.Annotations" Version="2021.3.0" />
     <PackageReference Include="JetBrains.DotMemoryUnit" Version="3.1.20200127.214830" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">


### PR DESCRIPTION
Updated packages roslyn, ms and jetbrains nuget package to latest stable.  

- .Net.SDK upgraded to 17.0.  
- Fixed where suggested from using deprecated .Kind() == value to .IsKind(value).